### PR TITLE
dedup threshold QOL

### DIFF
--- a/target/jamba.vpy
+++ b/target/jamba.vpy
@@ -88,6 +88,8 @@ if (in_scale := float(rc['timescale']['in'])) != 1.0:
 
 
 if (dt := rc['miscellaneous']['dedup threshold']).lower() not in NO:
+    if (dt := rc['miscellaneous']['dedup threshold']).lower() in YES:
+        dt = 0.001
     clip = filldrops.FillDrops(
         clip,
         thresh=float(dt)


### PR DESCRIPTION
If `dedup threshold` is in YES, then set the threshold value to 0.001.

**Why?**
This is because many users may be familiar with the way blur does it and expect to use the same value. However, it may be appropriate to rename the option since 'true' or 'yes' doesn't represent a threshold value.