### PR TITLE
weighting fixes

### DIFF
--- a/target/scripts/blending.py
+++ b/target/scripts/blending.py
@@ -112,7 +112,6 @@ def parse_weights2(clip: vs.VideoNode, fbd: dict[str, str]) -> list[float]:
         return fn(**params)
 
     for pair in to_parse:
-
         if '=' not in pair:
             raise ValueError(f'Options must be of the form "name=value", not "{pair}"')
 
@@ -125,14 +124,10 @@ def parse_weights2(clip: vs.VideoNode, fbd: dict[str, str]) -> list[float]:
             weighting.enable_wizardry()
             continue
 
-        # custom func is a string that literal_eval can't parse
-        if param != 'func':
-            value = parse_literal(value, param)
-
         if params.get(param) is not None:
             warnings.warn(f'Option "{param}" is set multiple times')
 
-        params[param] = value
+        params[param] = parse_literal(value, param)
 
     return fn(**params)
 
@@ -155,8 +150,6 @@ def _test_weights():
         '[1, 2, 3, 4, 5]',
         'gaussian; apex = 3; std_dev = 2.2',
         'gaussian_sym',
-        'custom; func = x**2',
-        'custom; func = x**2; bound = (0, 1)',
     )
 
     fps_vals = [60 * i for i in range(4, 12)]

--- a/target/scripts/blending.py
+++ b/target/scripts/blending.py
@@ -133,12 +133,10 @@ def parse_weights2(clip: vs.VideoNode, fbd: dict[str, str]) -> list[float]:
 
 
 def format_vec(v: list[float]):
-    rounded = [round(x, 3) for x in v]
-
-    if len(rounded) <= 3:
-        return str(rounded)
-
-    return str(rounded[0:2])[:-1] + ', ..., ' + str(rounded[-3:-1])[1:]
+    rounded = [f'{x:.2f}' for x in v]
+    if len(rounded) > 4:
+        rounded = rounded[:2] + ['...'] + rounded[-2:]
+    return f"[{', '.join(rounded)}]"
 
 
 def _test_weights():

--- a/target/scripts/weighting.py
+++ b/target/scripts/weighting.py
@@ -9,9 +9,12 @@ Reference:
 """
 
 import math
-import warnings as w
+import warnings
 from numbers import Number
 from typing import Iterable
+
+
+__all__ = ["ascending", "descending", "equal", "gaussian", "gaussian_sym", "pyramid", "divide", "enable_wizardry"]
 
 _wizardry_enabled = False
 
@@ -66,22 +69,21 @@ def equal(frames: int):
     return [1 / frames] * frames
 
 
-def gaussian(frames: int, apex: Number = 2, std_dev: Number = 1, bound: tuple[Number, Number] = (0, 2)):
+def gaussian(frames: int, mean: Number = 2, std_dev: Number = 1, bound: tuple[Number, Number] = (0, 2)):
     """
     Args:
-        bound: `[a, b]` | x axis vector from `a` to `b`
-        apex: `μ`       | the position of the center of the peak, relative to x axis vector
-        std_dev: `σ`    | width of the "bell", higher == broader/flatter
+        bound: `[a, b]` | range for the x-axis, from `a` to `b` (inclusive)
+        mean: `μ`       | the position of the center of the peak, relative to x-axis
+        std_dev: `σ`    | width of the "bell", higher <=> broader/flatter
     Reference:
         https://en.wikipedia.org/wiki/Gaussian_function
     """
     _warn_bound(bound, "gaussian")
 
-    r = scale_range(frames, bound[0], bound[1]) # x axis vector
+    x_axis = scale_range(frames, bound[0], bound[1])
 
-    val = [1 / (math.sqrt(2 * math.pi) * std_dev) # normalization
-           * math.exp(-((x - apex) / std_dev) ** 2 / 2) # gaussian function
-           for x in r]
+    val = [math.exp(-(x - mean) ** 2 / (2 * std_dev ** 2))
+           for x in x_axis]
 
     return normalize(val)
 
@@ -89,18 +91,12 @@ def gaussian(frames: int, apex: Number = 2, std_dev: Number = 1, bound: tuple[Nu
 def gaussian_sym(frames: int, std_dev: Number = 1, bound: tuple[Number, Number] = (0, 2)):
     """
     Same as `gaussian()` but symmetric;
-    the peak (apex) will always be at the center of the curve
+    the peak (mean) will always be at the center of the curve
     """
     _warn_bound(bound, "gaussian_sym")
 
     max_abs = max(map(abs, bound[:2]))
-    r = scale_range(frames, -max_abs, max_abs)
-
-    val = [1 / (math.sqrt(2 * math.pi) * std_dev)
-           * math.exp(-(x / std_dev) ** 2 / 2)
-           for x in r]
-
-    return normalize(val)
+    return gaussian(frames, mean=0, std_dev=std_dev, bound=(-max_abs, max_abs))
 
 
 def pyramid(frames: int):
@@ -109,49 +105,6 @@ def pyramid(frames: int):
     """
     half = (frames - 1) / 2
     val = [half - abs(x - half) + 1 for x in range(frames)]
-
-    return normalize(val)
-
-
-def func_eval(func: str, nums: list[float]):
-    """
-    Run an operation on a sequence of numbers
-    Names allowed in `func`:
-        - Everything in the `math` module
-        - `x`: the current number (frame) in the sequence
-        - `frames` (`len(nums)`): number of elements in the sequence (blended frames)
-        - The following built-in functions: `sum`, `abs`, `max`, `min`, `len`, `pow`, `map`, `range`, `round`
-    """
-
-    # math functions + math related builtins
-    namespace = {k: v for k, v in math.__dict__.items() if not k.startswith("_")}
-    namespace |= {
-        'frames': len(nums), # total number of items (frames)
-        'x': None, # iterator for nums
-        '__builtins__': {
-            'sum': sum,
-            'abs': abs,
-            'max': max,
-            'min': min,
-            'len': len,
-            'pow': pow,
-            'map': map,
-            'range': range,
-            'round': round
-        }
-    }
-    # only allow functions specified in namespace
-    return eval(f"[({func}) for x in {nums}]", namespace)
-
-
-def custom(frames: int, func: str = "", bound: tuple[Number, Number] = (0, 1)):
-    """
-    Arbitrary custom weighting function
-    """
-    _warn_bound(bound, "custom")
-
-    r = scale_range(frames, bound[0], bound[1])
-    val = func_eval(func, r)
 
     return normalize(val)
 
@@ -173,9 +126,6 @@ def _warn_bound(bound: tuple, func_name: str):
     if len(bound) < 2:
         raise ValueError(f"{func_name}: bound must be a sequence of length 2, got {bound}")
     elif len(bound) > 2:
-        w.warn(f"{func_name}: bound was given as a sequence of length {len(bound)}, "
-               f"only the first two values will be used (got {bound}))",
-               RuntimeWarning)
-
-
-__all__ = [ascending, descending, equal, gaussian, gaussian_sym, pyramid, custom, divide, enable_wizardry]
+        warnings.warn(f"{func_name}: bound was given as a sequence of length {len(bound)}, "
+                      f"only the first two values will be used (got {bound}))",
+                      RuntimeWarning)


### PR DESCRIPTION
- updated the weighting module to 1.2.0, fixing an rce vulnerability (removes custom weighting functions in favor of users precomputing the weights themselves and using the `[w1, w2, ..., wN]` syntax)
- updated `blending.parse_weights2` to take changes in version 1.2.0 into account
- fixed `blending.format_vec` printing incorrectly in some cases