### PR TITLE
fix order of blurframes

### DIFF
--- a/target/scripts/blending.py
+++ b/target/scripts/blending.py
@@ -17,9 +17,9 @@ logging.basicConfig(level=logging.DEBUG)
 def average(clip: vs.VideoNode, weights: list[float], divisor: float | None = None):
     def get_offset_clip(offset: int) -> vs.VideoNode:
         if offset > 0:
-            return clip[0] * offset + clip[:-offset]
+            return clip[offset:] + clip[-1] * offset
         elif offset < 0:
-            return clip[-offset:] + clip[-1] * (-offset)
+            return clip[0] * -offset + clip[:offset]
         else:
             return clip
 


### PR DESCRIPTION
made it so that frame blending will assign the first weights to past frames and the last weights to future frames, relative to the current frame being blended (it was the other way around before)