### PR TITLE
[FIX] Compile error on linux caused by DestroyWindow()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ fn main() {
         }
 
         if let Ok((args, recipe, hwnd)) = receiver.recv() {
+            #[cfg(windows)]
             unsafe {
                 let _ret = windows::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd.unwrap());
                 // dbg!(&_ret);


### PR DESCRIPTION
Fixed a compilation error on linux caused by the 
`windows::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd.unwrap());` function