### PR TITLE
Improve video rendering by implementing progress bar

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,8 +103,12 @@ pub struct Arguments {
 
     // debugging
     /// Display progress bar
-    #[clap(long, default_value_t = false)]
+    #[clap(long, default_value_t = true)]
     pub progress: bool,
+
+    /// Disable progress bar
+    #[clap(long)]
+    pub no_progress: bool,
 
     /// Display details about recipe, what I personally use
     #[clap(short, long, default_value_t = false)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     };
 
     let return_recipe = args.return_recipe;
-    let progress = args.progress;
+    let progress = args.progress && !args.no_progress;
 
     payloads = video::resolve_input(&mut args, &recipe);
     let commands: Vec<SmCommand> = cmd::build_commands(args, payloads, recipe);

--- a/src/render.rs
+++ b/src/render.rs
@@ -27,8 +27,13 @@ pub fn vspipe_render(commands: Vec<SmCommand>, mut progress: bool) {
         let vs = Command::new(cmd.vs_path)
             .args(cmd.vs_args)
             .stdout(Stdio::piped())
+            .stderr(if progress {
+                Stdio::null()
+            } else {
+                Stdio::inherit()
+            })
             .spawn()
-            .expect("Failed in spawning FFmpeg child");
+            .expect("Failed in spawning VSPipe child");
 
         let pipe = vs.stdout.expect("Failed piping out of VSPipe");
 


### PR DESCRIPTION
## Summary
Enhances the progress bar during video rendering with clearer labels and better default behavior.

## Changes
 - Enable progress bar by default (add `--no-progress` to disable)
 - Replace cryptic symbols with descriptive labels: `Rendered: X/Ys Time: 00:13 ETA: 00:06 Speed: 18 FPS`
 - Fix duplicate progress output by suppressing VSPipe stderr
 - Throttle updates to reduce terminal spam